### PR TITLE
fix RD calculation

### DIFF
--- a/glicko2.py
+++ b/glicko2.py
@@ -10,15 +10,14 @@
 """
 import math
 
-__version__ = "0.0.dev"
-
+__version__ = '0.0.dev'
 
 #: The actual score for win
-WIN = 1.0
+WIN = 1.
 #: The actual score for draw
 DRAW = 0.5
 #: The actual score for loss
-LOSS = 0.0
+LOSS = 0.
 
 
 MU = 1500
@@ -37,7 +36,7 @@ class Rating(object):
     def __repr__(self):
         c = type(self)
         args = (c.__module__, c.__name__, self.mu, self.phi, self.sigma)
-        return "%s.%s(mu=%.3f, phi=%.3f, sigma=%.3f)" % args
+        return '%s.%s(mu=%.3f, phi=%.3f, sigma=%.3f)' % args
 
 
 class Glicko2(object):
@@ -71,10 +70,10 @@ class Glicko2(object):
         """The original form is `g(RD)`. This function reduces the impact of
         games as a function of an opponent's RD.
         """
-        return 1 / math.sqrt(1 + (3 * rating.phi ** 2) / (math.pi ** 2))
+        return 1. / math.sqrt(1 + (3 * rating.phi ** 2) / (math.pi ** 2))
 
     def expect_score(self, rating, other_rating, impact):
-        return 1.0 / (1 + math.exp(-impact * (rating.mu - other_rating.mu)))
+        return 1. / (1 + math.exp(-impact * (rating.mu - other_rating.mu)))
 
     def determine_sigma(self, rating, difference, variance):
         """Determines new sigma."""
@@ -142,7 +141,7 @@ class Glicko2(object):
             variance_inv += impact ** 2 * expected_score * (1 - expected_score)
             difference += impact * (actual_score - expected_score)
         difference /= variance_inv
-        variance = 1.0 / variance_inv
+        variance = 1. / variance_inv
         # Step 5. Determine the new value, Sigma', ot the sigma. This
         #         computation requires iteration.
         sigma = self.determine_sigma(rating, difference, variance)
@@ -150,16 +149,14 @@ class Glicko2(object):
         #         value, Phi*.
         phi_star = math.sqrt(rating.phi ** 2 + sigma ** 2)
         # Step 7. Update the rating and RD to the new values, Mu' and Phi'.
-        phi = 1 / math.sqrt(1 / phi_star ** 2 + 1 / variance)
+        phi = 1. / math.sqrt(1 / phi_star ** 2 + 1 / variance)
         mu = rating.mu + phi ** 2 * (difference / variance)
         # Step 8. Convert ratings and RD's back to original scale.
         return self.scale_up(self.create_rating(mu, phi, sigma))
 
     def rate_1vs1(self, rating1, rating2, drawn=False):
-        return (
-            self.rate(rating1, [(DRAW if drawn else WIN, rating2)]),
-            self.rate(rating2, [(DRAW if drawn else LOSS, rating1)]),
-        )
+        return (self.rate(rating1, [(DRAW if drawn else WIN, rating2)]),
+                self.rate(rating2, [(DRAW if drawn else LOSS, rating1)]))
 
     def quality_1vs1(self, rating1, rating2):
         expected_score1 = self.expect_score(rating1, rating2, self.reduce_impact(rating1))

--- a/glicko2.py
+++ b/glicko2.py
@@ -10,16 +10,15 @@
 """
 import math
 
-
-__version__ = '0.0.dev'
+__version__ = "0.0.dev"
 
 
 #: The actual score for win
-WIN = 1.
+WIN = 1.0
 #: The actual score for draw
 DRAW = 0.5
 #: The actual score for loss
-LOSS = 0.
+LOSS = 0.0
 
 
 MU = 1500
@@ -33,7 +32,6 @@ Q = math.log(10) / 400
 
 
 class Rating(object):
-
     def __init__(self, mu=MU, phi=PHI, sigma=SIGMA):
         self.mu = mu
         self.phi = phi
@@ -42,11 +40,10 @@ class Rating(object):
     def __repr__(self):
         c = type(self)
         args = (c.__module__, c.__name__, self.mu, self.phi, self.sigma)
-        return '%s.%s(mu=%.3f, phi=%.3f, sigma=%.3f)' % args
+        return "%s.%s(mu=%.3f, phi=%.3f, sigma=%.3f)" % args
 
 
 class Glicko2(object):
-
     def __init__(self, mu=MU, phi=PHI, sigma=SIGMA, tau=TAU, epsilon=EPSILON):
         self.mu = mu
         self.phi = phi
@@ -80,7 +77,7 @@ class Glicko2(object):
         return 1 / math.sqrt(1 + (3 * rating.phi ** 2) / (math.pi ** 2))
 
     def expect_score(self, rating, other_rating, impact):
-        return 1. / (1 + math.exp(-impact * (rating.mu - other_rating.mu)))
+        return 1.0 / (1 + math.exp(-impact * (rating.mu - other_rating.mu)))
 
     def determine_sigma(self, rating, difference, variance):
         """Determines new sigma."""
@@ -88,6 +85,7 @@ class Glicko2(object):
         difference_squared = difference ** 2
         # 1. Let a = ln(s^2), and define f(x)
         alpha = math.log(rating.sigma ** 2)
+
         def f(x):
             """This function is twice the conditional log-posterior density of
             phi, and is the optimality criterion.
@@ -96,6 +94,7 @@ class Glicko2(object):
             a = math.exp(x) * (difference_squared - tmp) / (2 * tmp ** 2)
             b = (x - alpha) / (self.tau ** 2)
             return a - b
+
         # 2. Set the initial values of the iterative algorithm.
         a = alpha
         if difference_squared > phi ** 2 + variance:
@@ -133,7 +132,6 @@ class Glicko2(object):
         # Step 4. Compute the quantity difference, the estimated improvement in
         #         rating by comparing the pre-period rating to the performance
         #         rating based only on game outcomes.
-        d_square_inv = 0
         variance_inv = 0
         difference = 0
         if not series:
@@ -146,19 +144,14 @@ class Glicko2(object):
             expected_score = self.expect_score(rating, other_rating, impact)
             variance_inv += impact ** 2 * expected_score * (1 - expected_score)
             difference += impact * (actual_score - expected_score)
-            d_square_inv += (
-                expected_score * (1 - expected_score) *
-                (Q ** 2) * (impact ** 2))
         difference /= variance_inv
-        variance = 1. / variance_inv
-        denom = rating.phi ** -2 + d_square_inv
-        phi = math.sqrt(1 / denom)
+        variance = 1.0 / variance_inv
         # Step 5. Determine the new value, Sigma', ot the sigma. This
         #         computation requires iteration.
         sigma = self.determine_sigma(rating, difference, variance)
         # Step 6. Update the rating deviation to the new pre-rating period
         #         value, Phi*.
-        phi_star = math.sqrt(phi ** 2 + sigma ** 2)
+        phi_star = math.sqrt(rating.phi ** 2 + sigma ** 2)
         # Step 7. Update the rating and RD to the new values, Mu' and Phi'.
         phi = 1 / math.sqrt(1 / phi_star ** 2 + 1 / variance)
         mu = rating.mu + phi ** 2 * (difference / variance)
@@ -166,8 +159,10 @@ class Glicko2(object):
         return self.scale_up(self.create_rating(mu, phi, sigma))
 
     def rate_1vs1(self, rating1, rating2, drawn=False):
-        return (self.rate(rating1, [(DRAW if drawn else WIN, rating2)]),
-                self.rate(rating2, [(DRAW if drawn else LOSS, rating1)]))
+        return (
+            self.rate(rating1, [(DRAW if drawn else WIN, rating2)]),
+            self.rate(rating2, [(DRAW if drawn else LOSS, rating1)]),
+        )
 
     def quality_1vs1(self, rating1, rating2):
         expected_score1 = self.expect_score(rating1, rating2, self.reduce_impact(rating1))

--- a/glicko2.py
+++ b/glicko2.py
@@ -26,9 +26,6 @@ PHI = 350
 SIGMA = 0.06
 TAU = 1.0
 EPSILON = 0.000001
-#: A constant which is used to standardize the logistic function to
-#: `1/(1+exp(-x))` from `1/(1+10^(-r/400))`
-Q = math.log(10) / 400
 
 
 class Rating(object):

--- a/glicko2tests.py
+++ b/glicko2tests.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from glicko2 import DRAW, LOSS, WIN, Glicko2
+from glicko2 import Glicko2, WIN, DRAW, LOSS
 
 
 class almost(object):
+
     def __init__(self, val, precision=3):
         self.val = val
         self.precision = precision
@@ -10,8 +11,8 @@ class almost(object):
     def almost_equals(self, val1, val2):
         if round(val1, self.precision) == round(val2, self.precision):
             return True
-        fmt = "%.{0}f".format(self.precision)
-        mantissa = lambda f: int((fmt % f).replace(".", ""))
+        fmt = '%.{0}f'.format(self.precision)
+        mantissa = lambda f: int((fmt % f).replace('.', ''))
         return abs(mantissa(val1) - mantissa(val2)) <= 1
 
     def __eq__(self, other):
@@ -20,9 +21,8 @@ class almost(object):
                 return False
         except AttributeError:
             pass
-        return self.almost_equals(self.val.mu, other.mu) and self.almost_equals(
-            self.val.sigma, other.sigma
-        )
+        return (self.almost_equals(self.val.mu, other.mu) and
+                self.almost_equals(self.val.sigma, other.sigma))
 
     def __repr__(self):
         return repr(self.val)
@@ -35,6 +35,5 @@ def test_glickman_example():
     r3 = env.create_rating(1550, 100)
     r4 = env.create_rating(1700, 300)
     rated = env.rate(r1, [(WIN, r2), (LOSS, r3), (LOSS, r4)])
-    print("rated:", rated)
     # env.create_rating2(1464.06, 151.52, 0.05999)
     assert almost(rated) == env.create_rating(1464.051, 151.515, 0.05999)

--- a/glicko2tests.py
+++ b/glicko2tests.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-from glicko2 import Glicko2, WIN, DRAW, LOSS
+from glicko2 import DRAW, LOSS, WIN, Glicko2
 
 
 class almost(object):
-
     def __init__(self, val, precision=3):
         self.val = val
         self.precision = precision
@@ -11,8 +10,8 @@ class almost(object):
     def almost_equals(self, val1, val2):
         if round(val1, self.precision) == round(val2, self.precision):
             return True
-        fmt = '%.{0}f'.format(self.precision)
-        mantissa = lambda f: int((fmt % f).replace('.', ''))
+        fmt = "%.{0}f".format(self.precision)
+        mantissa = lambda f: int((fmt % f).replace(".", ""))
         return abs(mantissa(val1) - mantissa(val2)) <= 1
 
     def __eq__(self, other):
@@ -21,8 +20,9 @@ class almost(object):
                 return False
         except AttributeError:
             pass
-        return (self.almost_equals(self.val.mu, other.mu) and
-                self.almost_equals(self.val.sigma, other.sigma))
+        return self.almost_equals(self.val.mu, other.mu) and self.almost_equals(
+            self.val.sigma, other.sigma
+        )
 
     def __repr__(self):
         return repr(self.val)
@@ -35,5 +35,6 @@ def test_glickman_example():
     r3 = env.create_rating(1550, 100)
     r4 = env.create_rating(1700, 300)
     rated = env.rate(r1, [(WIN, r2), (LOSS, r3), (LOSS, r4)])
+    print("rated:", rated)
     # env.create_rating2(1464.06, 151.52, 0.05999)
     assert almost(rated) == env.create_rating(1464.051, 151.515, 0.05999)


### PR DESCRIPTION
I believe the way of calculating the new `RD` is incorrect.

In the [glicko2 document by Glickman](http://www.glicko.net/glicko/glicko2.pdf) the new `RD` or `phi` value is calculated with the following steps:

1. `phi_star = sqrt(phi^2 + sigma_prime^2)` Here the `phi` variable is the pre-rating period uncertainty 
2. `phi_prime = 1 / sqrt(1/phi_star^2 + 1/variance)`

while currently the code calculates `phi_prime` (`RD_prime`)  in the way of the [original Glicko 1 document](http://www.glicko.net/glicko/glicko.pdf)

then it also does steps 1 and 2 of the Glicko 2 system on top of this. I believe according to the Glicko 2 documentation, this step is redundant/incorrect

The relevant changes are in `rate` function, the other changes are linter changes by the `black` linter, that my VS code automatically did. 